### PR TITLE
Choose the right set when dropping L1 victim to L2

### DIFF
--- a/ExclusiveHierarchy.cpp
+++ b/ExclusiveHierarchy.cpp
@@ -69,59 +69,52 @@ ExclusiveHierarchy::ACCESS_STATUS ExclusiveHierarchy::access(addr_t address)
 
     LRUSet& L2_set = L2_cache[L2_set_index];
 
-    unsigned L2_min_age = std::numeric_limits<unsigned>::max();
-
-    auto L2_victim = L2_set.lines.end();
-
-    for (auto way = L2_set.lines.begin(); way < L2_set.lines.end(); ++way)
+    bool L2_hit = false;
+    for (auto way = L2_set.lines.begin(); way < L2_set.lines.end() && !L2_hit; ++way)
     {
-
         //L2 hit
         if (way->tag == L2_tag && way->time != TIME_INVALID)
         {
-            //The L1 victim is valid and must therefore be installed in L2
-            if (L1_min_age != TIME_INVALID)
-            {
-                /* Compute the L2 tag from the full address stored in the L1 victim's tag field.
-                 * See the comment at the beginning of this method */
-                way->tag = get_tag(L1_victim->tag, L2_config);
-                way->time = ++L2_set.max_age;
-            }
+            /* invalidate immediately the L2 entry. Important to do it first, so that this entry
+             * can potentially be reused immediately (this happen only if the L1 victim belongs to this set,
+             * and if this slot is the first invalid slot) */
+            way->time = TIME_INVALID;
 
-            //The L1 victim is invalid. We don't need to put it in L2, so simply invalidate the L2 hit entry
-            else
-                way->time = TIME_INVALID;
-
-            //Install the new line in L1
-            L1_victim->tag = aligned_address;
-            L1_victim->time = ++L1_set.max_age;
-
-            return ACCESS_STATUS::L1_MISS_L2_HIT;
-        }
-
-        else
-        {
-            if (way->time < L2_min_age)
-            {
-                L2_min_age = way->time;
-                L2_victim = way;
-            }
+            L2_hit = true;
         }
     }
-    //L2 miss
 
-    //Install the L1 victim in L2 only if it is valid
+    /* The L1 victim is valid and must be installed in L2.
+     * Important: The set where the L1 victim will be installed is not necessarily the same as
+     * the set where the requested line was searched!*/
     if (L1_min_age != TIME_INVALID)
     {
-        /* Compute the L2 tag from the full address stored in the L1 victim's tag field.
-         * See the comment at the beginning of this method */
+        const addr_t L2_victim_set_index = get_set_index(L1_victim->tag, L2_config);
+        LRUSet& L2_victim_set = L2_cache[L2_victim_set_index];
+        auto L2_victim = find_victim(L2_victim_set);
         L2_victim->tag = get_tag(L1_victim->tag, L2_config);
-        L2_victim->time = ++L2_set.max_age;
+        L2_victim->time = ++L2_victim_set.max_age;
     }
 
     //Install the new line in L1
     L1_victim->tag = aligned_address;
     L1_victim->time = ++L1_set.max_age;
 
-    return ACCESS_STATUS::L1_MISS_L2_MISS;
+    return L2_hit ? ACCESS_STATUS::L1_MISS_L2_HIT : ACCESS_STATUS::L1_MISS_L2_MISS;
+}
+
+std::vector<LRUCacheLine>::iterator ExclusiveHierarchy::find_victim(LRUSet& set) const
+{
+    auto victim = set.lines.end();
+    unsigned min_age = std::numeric_limits<unsigned>::max();
+
+    for (auto way = set.lines.begin(); way < set.lines.end(); ++way)
+    {
+        if (way->time < min_age)
+        {
+            victim = way;
+            min_age = victim->time;
+        }
+    }
+    return victim;
 }

--- a/ExclusiveHierarchy.h
+++ b/ExclusiveHierarchy.h
@@ -13,7 +13,7 @@ class ExclusiveHierarchy
     std::vector<LRUSet> L1_cache;
     std::vector<LRUSet> L2_cache;
 
-
+    std::vector<LRUCacheLine>::iterator find_victim(LRUSet& set) const;
 public:
     enum class ACCESS_STATUS {L1_HIT, L1_MISS_L2_HIT, L1_MISS_L2_MISS};
 


### PR DESCRIPTION
If L1 and L2 have a different number of sets, then the L2 set where the
requested address is searched is not the same as the set where the L1
victim should be installed.
